### PR TITLE
fix(*): 修复全局mixin导致报错

### DIFF
--- a/client.js
+++ b/client.js
@@ -21,13 +21,13 @@ Vue.use(fetchPlugin);
 
 const context = __vue_context_data;
 
-Vue.mixin({
-    data: function () {
-        return context;
-    }
-})
-
 const view = require('./' + context.pageContext.pageAction + '.vue');
+
+view.mixins = [{
+  data: function () {
+    return context;
+  }
+}];
 
 new Vue(view).$mount('#wrapper');
 

--- a/example/src/components/widget.vue
+++ b/example/src/components/widget.vue
@@ -1,0 +1,11 @@
+<template>
+  <div v-if="show">
+    this is a {{ msg }}
+  </div>
+</template>
+
+<script>
+  export default {
+    props: ['show', 'msg']
+  }
+</script>

--- a/example/src/pages/index/view.vue
+++ b/example/src/pages/index/view.vue
@@ -1,37 +1,33 @@
 <template>
-    <div id="wrapper">
+  <div id="wrapper">
+    <widget :show="true" :msg="msg"></widget>
+    <h1>hello! {{ msg }} 测试更新!!!</h1>
 
-        <h1>hello! {{ msg }} 测试更新!!!</h1>
-
-        <h2>{{ text }}</h2>
-    </div>
+    <h2>{{ text }}</h2>
+  </div>
 </template>
 
 <script>
-    // import HeaderComponent from './components/header.vue'
+  import widget from '../../components/widget.vue'
 
-    var data = {};
+  export default{
+    components: { widget },
+    methods: {
+      fetchAPI: function (data) {
+        this.msg = data.msg;
+        this.text = data.text;
+      },
 
-    export default{
-
-        methods: {
-
-            fetchAPI: function (data) {
-                this.msg = data.msg;
-                this.text = data.text;
-            },
-
-            doSomething: function (event) {
-                console.log(this.ek);
-                alert('Hello ' + this.ek + '!')
-            }
-        }
-
+      doSomething: function (event) {
+        console.log(this.ek);
+        alert('Hello ' + this.ek + '!')
+      }
     }
+
+  }
 </script>
 
-<style lang="stylus">
+<style lang="stylus" rel="stylesheet/stylus">
   body
     background #444
-
 </style>

--- a/vue.js
+++ b/vue.js
@@ -6,12 +6,11 @@ export default function (context) {
 
     let View = require('./' + action + '.vue');
 
-
-    Vue.mixin({
+    View.mixins = [{
         data: function () {
-            return context;
+          return context;
         }
-    })
+    }];
 
     const app = new Vue(Object.assign(View, {
         // data:function(){


### PR DESCRIPTION
mixin 应只混合页面组件

全局使用mixin传入context作为data，对页面引用的组件其实没有意义，且当属性名称相同时会报错。