### PR TITLE
增加 logid，用于关联请求日志

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "AGPL-3.0",
   "author": "yingjunjiao",
   "dependencies": {
-    "@quancheng/saluki2-node": "1.2.7",
+    "@quancheng/saluki2-node": "1.2.8",
     "autoprefixer": "6.5.3",
     "babel-cli": "6.16.0",
     "babel-core": "6.17.0",

--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -134,7 +134,8 @@ export default function (opts = {}) {
 
         let timer = new ctx.logger.Timer({
             group: 'request',
-            path: `${ctx.method} ${ctx.url}`
+            path: `${ctx.method} ${ctx.url}`,
+            logid: ctx.requestId
         });
 
         await next();

--- a/src/middleware/route.js
+++ b/src/middleware/route.js
@@ -122,7 +122,9 @@ export default function (opts = {}) {
                                 });
                                 let result
                                 try {
-
+                                    // set logid for services
+                                    args[1] = Object.assign({'qc-logid': ctx.requestId}, args[1] ? args[1] : {})
+                                    
                                     result = await origMethod.apply(this, args);
                                 } catch (e) {
                                     console.error('error method:' + propKey, e)


### PR DESCRIPTION
1. 日志增加字段：logid
2. @quancheng/saluki2-node: “1.2.8”（服务调用支持传入metadata）
3. 默认调用服务传入 logid